### PR TITLE
Add GitHub Pages friendly architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ available at:
 https://<your-github-username>.github.io/whoom/
 ```
 
-Replace `<your-github-username>` with the owner of the repository. The backend
-must be running separately (for example on your local machine or a server) and
-the frontend can be configured to point to it via the
-`REACT_APP_API_BASE_URL` environment variable when building.
+Replace `<your-github-username>` with the owner of the repository.
+
+### Running entirely on GitHub Pages
+
+GitHub Pages only hosts static files, so a Python backend cannot run there. To
+use the app without a separate server you can run all language model calls
+directly from the browser. In this mode users provide their own API key and the
+frontend communicates with the LLM provider. See
+[docs/github_pages_architecture.md](docs/github_pages_architecture.md) for a
+description of this approach.
+
+The previous FastAPI backend remains useful for local development or if you
+prefer to proxy requests through your own service. When using a separate backend
+the frontend can be configured via the `REACT_APP_API_BASE_URL` environment
+variable when building.

--- a/docs/github_pages_architecture.md
+++ b/docs/github_pages_architecture.md
@@ -1,0 +1,17 @@
+# GitHub Pages Compatible Architecture
+
+GitHub Pages only serves static files and cannot host a Python backend. To run the full application directly from Pages, the backend functionality needs to move to the browser.
+
+## Client-Only Approach
+
+1. **Static React Frontend** – The `frontend/` project builds to static files that GitHub Pages hosts.
+2. **User Supplied API Key** – When the page loads, the user enters their OpenAI/Anthropic API key. The key is kept in local storage and sent with each request.
+3. **LLM Calls From the Browser** – The React app calls the language model APIs directly using the provided key. Both generation and analysis happen client‑side.
+4. **No Server Required** – Because all requests go straight to the LLM provider, no FastAPI service or other backend needs to be running.
+
+This approach keeps the deployment entirely within GitHub Pages while still providing all functionality.
+
+## Optional Serverless Backend
+
+If maintaining an API key in the client is not desired, you can deploy a small serverless function (for example on Cloudflare Workers or AWS Lambda) that proxies the LLM requests. The React frontend on GitHub Pages can then call this function instead of contacting the LLM provider directly.
+


### PR DESCRIPTION
## Summary
- document running the app entirely from GitHub Pages
- outline client-only architecture

## Testing
- `npm test --silent --yes` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa15e2df88332b6a5b1a35d2572bf