### PR TITLE
Add conversation persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ Users provide their own API key and the React frontend communicates directly
 with the LLM provider. See
 [docs/github_pages_architecture.md](docs/github_pages_architecture.md) for a
 description of this approach.
+
+### Conversation Persistence
+
+All branches and messages are automatically saved in your browser's local
+storage. Reloading the page restores the previous conversation. Use the **Reset**
+button in the interface to clear the stored data or **Export** to download a JSON
+copy of your chat history.

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -77,6 +77,7 @@ User input ─► LLM completion ─► response
    - Allow user-written text decomposition and hybrid turns.
    - Implement advanced character evolution (merging, splitting, new appearances).
    - Provide options to save conversations and character configurations.
+   - Conversations persist in local storage between sessions.
 
 4. **Long Term**
    - Expose the character decomposition as an API for other tools.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -92,3 +92,15 @@
   background-color: #ddd;
   cursor: default;
 }
+
+.controls {
+  margin-bottom: 20px;
+}
+
+.controls button {
+  margin-right: 10px;
+  padding: 5px 10px;
+  border: 1px solid #ddd;
+  background-color: #f5f5f5;
+  cursor: pointer;
+}

--- a/frontend/src/services/storage.js
+++ b/frontend/src/services/storage.js
@@ -1,0 +1,26 @@
+const BRANCHES_KEY = 'cdc_branches';
+const CURRENT_BRANCH_KEY = 'cdc_current_branch';
+
+export const loadConversation = () => {
+    try {
+        const branches = JSON.parse(localStorage.getItem(BRANCHES_KEY) || 'null');
+        const currentBranchId = localStorage.getItem(CURRENT_BRANCH_KEY) || null;
+        return { branches, currentBranchId };
+    } catch (e) {
+        return { branches: null, currentBranchId: null };
+    }
+};
+
+export const saveConversation = (branches, currentBranchId) => {
+    try {
+        localStorage.setItem(BRANCHES_KEY, JSON.stringify(branches));
+        localStorage.setItem(CURRENT_BRANCH_KEY, currentBranchId || '');
+    } catch (e) {
+        console.error('Failed to save conversation', e);
+    }
+};
+
+export const clearConversation = () => {
+    localStorage.removeItem(BRANCHES_KEY);
+    localStorage.removeItem(CURRENT_BRANCH_KEY);
+};


### PR DESCRIPTION
## Summary
- store conversation branches in browser storage
- add controls to export or reset the chat
- document persistence behavior in README and development plan

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840aa2fe5ac83329d2950e862428c51