### PR TITLE
Add human written mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ All branches and messages are automatically saved in your browser's local
 storage. Reloading the page restores the previous conversation. Use the **Reset**
 button in the interface to clear the stored data, **Export** to download a JSON
 copy of your chat history, or **Import** to load a previously saved file.
+
+### Human-Written Mode
+
+Use the radio buttons below the branch controls to switch between **AI mode** and
+**Human-written mode**. In human-written mode your input is treated as the next
+assistant message. The text you supply is analyzed just like an AI response so
+characters can still be selected and branched.

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -31,6 +31,7 @@ This document outlines the current vision and feature set for **Character Decomp
    - **AI mode**: the LLM generates text which is then decomposed.
    - **Human‑written mode**: users can supply their own text to be decomposed in the same way.
    - Hybrid flows are possible, similar to how AI Dungeon allows both AI and human turns.
+   - The initial implementation of human-written mode lets you enter the assistant's reply manually and still performs character analysis on that text.
 
 5. **Web Interface**
    - A static React frontend communicates directly with the LLM provider.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -105,6 +105,15 @@
   cursor: pointer;
 }
 
+.mode-select {
+  margin-bottom: 20px;
+}
+
+.mode-select label {
+  margin-right: 15px;
+  cursor: pointer;
+}
+
 .import-button {
   margin-right: 10px;
   padding: 5px 10px;


### PR DESCRIPTION
## Summary
- allow toggling between AI generated and human supplied assistant replies
- analyze user-provided replies in human-written mode
- document new feature in the README and development plan
- style and render the mode selector

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840ac85e6bc833282c001a0b7f42bec