### PR TITLE
Add multiple AI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ To have the site show up when visiting `https://<your-github-username>.github.io
 ### Running entirely on GitHub Pages
 
 GitHub Pages only hosts static files, so the entire app now runs in the browser.
-Users provide their own API key and the React frontend communicates directly
-with the LLM provider. See
+Users choose an LLM provider (OpenAI, Anthropic, Google Gemini or a local Llama
+server) and supply the appropriate API key. The React frontend communicates
+directly with the selected provider. See
 [docs/github_pages_architecture.md](docs/github_pages_architecture.md) for a
 description of this approach.
 

--- a/docs/github_pages_architecture.md
+++ b/docs/github_pages_architecture.md
@@ -5,7 +5,7 @@ GitHub Pages only serves static files and cannot host a Python backend. To run t
 ## Client-Only Approach
 
 1. **Static React Frontend** – The `frontend/` project builds to static files that GitHub Pages hosts.
-2. **User Supplied API Key** – When the page loads, the user enters their OpenAI/Anthropic API key. The key is kept in local storage and sent with each request.
+2. **User Supplied API Key** – When the page loads, the user selects an LLM provider (OpenAI, Anthropic, Gemini or a local Llama server) and enters the corresponding API key. The key is kept in local storage and sent with each request.
 3. **LLM Calls From the Browser** – The React app calls the language model APIs directly using the provided key. Both generation and analysis happen client‑side.
 4. **No Server Required** – Because all requests go straight to the LLM provider, no FastAPI service or other backend needs to be running.
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { generateResponse, analyzeResponse, setApiKey as storeApiKey } from './services/api';
+import {
+    generateResponse,
+    analyzeResponse,
+    setApiKey as storeApiKey,
+    setProvider as storeProvider,
+} from './services/api';
 import { loadConversation, saveConversation, clearConversation } from './services/storage';
 import './App.css';
 
@@ -11,7 +16,8 @@ function App() {
     const [inputText, setInputText] = useState('');
     const [selectedCharacters, setSelectedCharacters] = useState([]);
     const [loading, setLoading] = useState(false);
-    const [apiKey, setApiKey] = useState(localStorage.getItem('openai_api_key') || '');
+    const [provider, setProvider] = useState(localStorage.getItem('provider') || 'openai');
+    const [apiKey, setApiKey] = useState(localStorage.getItem(`${(localStorage.getItem('provider') || 'openai')}_api_key`) || '');
 
     const currentBranch = branches.find(b => b.id === currentBranchId) || branches[0];
 
@@ -24,10 +30,15 @@ function App() {
     }, []);
 
     useEffect(() => {
+        storeProvider(provider);
+        setApiKey(localStorage.getItem(`${provider}_api_key`) || '');
+    }, [provider]);
+
+    useEffect(() => {
         if (apiKey) {
-            storeApiKey(apiKey);
+            storeApiKey(apiKey, provider);
         }
-    }, [apiKey]);
+    }, [apiKey, provider]);
 
     useEffect(() => {
         saveConversation(branches, currentBranchId);
@@ -38,7 +49,7 @@ function App() {
     };
 
     const handleSendMessage = async () => {
-        if (!inputText.trim() || loading || !apiKey) return;
+        if (!inputText.trim() || loading || (!apiKey && provider !== 'llama')) return;
 
         const newMessage = { role: 'user', content: inputText };
         const updatedMessages = [...currentBranch.messages, newMessage];
@@ -137,11 +148,17 @@ function App() {
         <div className="App">
             <h1>Character Decomposition Chat</h1>
             <div className="api-key">
+                <select value={provider} onChange={(e) => setProvider(e.target.value)}>
+                    <option value="openai">OpenAI</option>
+                    <option value="anthropic">Anthropic</option>
+                    <option value="gemini">Gemini</option>
+                    <option value="llama">Llama</option>
+                </select>
                 <input
                     type="password"
                     value={apiKey}
                     onChange={(e) => setApiKey(e.target.value)}
-                    placeholder="OpenAI API key"
+                    placeholder={`${provider} API key`}
                 />
             </div>
 
@@ -206,7 +223,7 @@ function App() {
                     placeholder="Type your message..."
                     disabled={loading}
                 />
-                <button onClick={handleSendMessage} disabled={loading || !inputText.trim() || !apiKey}>
+                <button onClick={handleSendMessage} disabled={loading || !inputText.trim() || (!apiKey && provider !== 'llama')}>
                     {loading ? 'Loading...' : 'Send'}
                 </button>
             </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,56 +1,97 @@
 import axios from 'axios';
 
-let apiKey = localStorage.getItem('openai_api_key') || '';
-
-export const setApiKey = (key) => {
-    apiKey = key;
-    localStorage.setItem('openai_api_key', key);
+let provider = localStorage.getItem('provider') || 'openai';
+const apiKeys = {
+    openai: localStorage.getItem('openai_api_key') || '',
+    anthropic: localStorage.getItem('anthropic_api_key') || '',
+    gemini: localStorage.getItem('gemini_api_key') || '',
+    llama: localStorage.getItem('llama_api_key') || '',
 };
 
-const openai = axios.create({
-    baseURL: 'https://api.openai.com/v1',
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
+export const setProvider = (p) => {
+    provider = p;
+    localStorage.setItem('provider', p);
+};
 
-export const generateResponse = async (messages, selectedCharacters = []) => {
-    if (!apiKey) throw new Error('API key not set');
-    const payload = {
-        model: 'gpt-3.5-turbo',
-        messages,
-    };
-    const response = await openai.post('/chat/completions', payload, {
-        headers: { Authorization: `Bearer ${apiKey}` },
-    });
-    return { response: response.data.choices[0].message.content, status: 'success' };
+export const setApiKey = (key, p = provider) => {
+    apiKeys[p] = key;
+    localStorage.setItem(`${p}_api_key`, key);
+};
+
+const callLLM = async (messages) => {
+    const key = apiKeys[provider];
+    if (!key && provider !== 'llama') throw new Error('API key not set');
+
+    switch (provider) {
+        case 'openai': {
+            const openai = axios.create({
+                baseURL: 'https://api.openai.com/v1',
+                headers: { 'Content-Type': 'application/json' },
+            });
+            const payload = { model: 'gpt-3.5-turbo', messages };
+            const resp = await openai.post('/chat/completions', payload, {
+                headers: { Authorization: `Bearer ${key}` },
+            });
+            return resp.data.choices[0].message.content;
+        }
+        case 'anthropic': {
+            const anthropic = axios.create({
+                baseURL: 'https://api.anthropic.com/v1',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-api-key': key,
+                    'anthropic-version': '2023-06-01',
+                },
+            });
+            const payload = { model: 'claude-3-haiku-20240307', messages, max_tokens: 1024 };
+            const resp = await anthropic.post('/messages', payload);
+            return resp.data.content[0].text;
+        }
+        case 'gemini': {
+            const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${key}`;
+            const contents = messages.map((m) => ({
+                role: m.role === 'assistant' ? 'model' : 'user',
+                parts: [{ text: m.content }],
+            }));
+            const payload = { contents };
+            const resp = await axios.post(url, payload);
+            const parts = resp.data.candidates[0].content.parts;
+            return parts.map((p) => p.text).join('');
+        }
+        case 'llama': {
+            const ollama = axios.create({ baseURL: 'http://localhost:11434' });
+            const payload = { model: 'llama2', messages };
+            const resp = await ollama.post('/api/chat', payload);
+            return resp.data.message.content;
+        }
+        default:
+            throw new Error('Unknown provider');
+    }
+};
+
+export const generateResponse = async (messages) => {
+    const content = await callLLM(messages);
+    return { response: content, status: 'success' };
 };
 
 export const analyzeResponse = async (responseText) => {
-    if (!apiKey) throw new Error('API key not set');
     const prompt = `Identify 2-3 distinct characters or perspectives in the following text and return a JSON array under the key "characters". Each character should have a name and short description.\n\n${responseText}`;
-    const payload = {
-        model: 'gpt-3.5-turbo',
-        messages: [
-            { role: 'system', content: 'You analyze text and extract characters.' },
-            { role: 'user', content: prompt },
-        ],
-    };
-    const response = await openai.post('/chat/completions', payload, {
-        headers: { Authorization: `Bearer ${apiKey}` },
-    });
+    const analysisMessages = [
+        { role: 'system', content: 'You analyze text and extract characters.' },
+        { role: 'user', content: prompt },
+    ];
     try {
-        const data = JSON.parse(response.data.choices[0].message.content);
+        const content = await callLLM(analysisMessages);
+        const data = JSON.parse(content);
         return data;
-    } catch (e) {
+    } catch {
         return { characters: [] };
     }
 };
 
-const api = {
+export default {
+    setProvider,
     setApiKey,
     generateResponse,
     analyzeResponse,
 };
-
-export default api;


### PR DESCRIPTION
## Summary
- support selection of OpenAI, Anthropic, Gemini or local Llama
- store API keys separately for each provider
- update UI with provider dropdown
- document the multi-provider approach

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840accc40f4833282bc40721da77489