### PR TITLE
Fix GitHub Pages build failures

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -120,12 +120,26 @@
 .branches button,
 .controls button,
 .import-button {
-  margin-right: 10px;
-  padding: 5px 10px;
-  background-color: #111;
-  border: 1px solid #333;
+    margin-right: 10px;
+    padding: 5px 10px;
+    background-color: #111;
+    border: 1px solid #333;
+    color: #b6ffb6;
+    cursor: pointer;
+}
+
+.api-key {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.api-key select,
+.api-key input {
+  padding: 5px;
+  background-color: #000;
   color: #b6ffb6;
-  cursor: pointer;
+  border: 1px solid #333;
 }
 
 .mode-select label {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,7 +17,9 @@ function App() {
     const [inputText, setInputText] = useState('');
     const [selectedCharacters, setSelectedCharacters] = useState([]);
     const [loading, setLoading] = useState(false);
-    const [provider, setProvider] = useState(localStorage.getItem('provider') || 'openai');
+    const [provider, setProvider] = useState(
+        localStorage.getItem('provider') || 'openai'
+    );
     const [apiKey, setApiKey] = useState(
         localStorage.getItem(`${localStorage.getItem('provider') || 'openai'}_api_key`) || ''
     );
@@ -194,11 +196,21 @@ function App() {
                 <header className="app-header">
                     <h1>Character Decomposition Chat</h1>
                     <div className="api-key">
+                        <select
+                            value={provider}
+                            onChange={(e) => setProvider(e.target.value)}
+                        >
+                            <option value="openai">OpenAI</option>
+                            <option value="anthropic">Anthropic</option>
+                            <option value="gemini">Gemini</option>
+                            <option value="llama">Local Llama</option>
+                        </select>
                         <input
                             type="password"
                             value={apiKey}
                             onChange={(e) => setApiKey(e.target.value)}
-                            placeholder="OpenAI API key"
+                            placeholder={`${provider.charAt(0).toUpperCase() + provider.slice(1)} API key`}
+                            disabled={provider === 'llama'}
                         />
                     </div>
                 </header>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -92,9 +92,11 @@ export const analyzeResponse = async (responseText, prevCharacters = []) => {
     }
 };
 
-export default {
+const api = {
     setProvider,
     setApiKey,
     generateResponse,
     analyzeResponse,
 };
+
+export default api;


### PR DESCRIPTION
## Summary
- add provider dropdown next to API key input
- style provider selector
- avoid anonymous default export in API module

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841267132e08332a2268cc3b2310f8f