### PR TITLE
Remove API keys from local storage

### DIFF
--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -35,7 +35,7 @@ This document outlines the current vision and feature set for **Character Decomp
 
 5. **Web Interface**
    - A static React frontend communicates directly with the LLM provider.
-   - The user supplies an API key which is stored locally in the browser.
+    - The user supplies an API key which is kept only in memory for the session.
    - Characters and branches are visualized, starting with a simple tree view.
 
 ## Architecture

--- a/docs/github_pages_architecture.md
+++ b/docs/github_pages_architecture.md
@@ -5,7 +5,7 @@ GitHub Pages only serves static files and cannot host a Python backend. To run t
 ## Client-Only Approach
 
 1. **Static React Frontend** – The `frontend/` project builds to static files that GitHub Pages hosts.
-2. **User Supplied API Key** – When the page loads, the user selects an LLM provider (OpenAI, Anthropic, Gemini or a local Llama server) and enters the corresponding API key. The key is kept in local storage and sent with each request.
+2. **User Supplied API Key** – When the page loads, the user selects an LLM provider (OpenAI, Anthropic, Gemini or a local Llama server) and enters the corresponding API key. The key is stored only in memory for the current session and sent with each request.
 3. **LLM Calls From the Browser** – The React app calls the language model APIs directly using the provided key. Both generation and analysis happen client‑side.
 4. **No Server Required** – Because all requests go straight to the LLM provider, no FastAPI service or other backend needs to be running.
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,9 +20,7 @@ function App() {
     const [provider, setProvider] = useState(
         localStorage.getItem('provider') || 'openai'
     );
-    const [apiKey, setApiKey] = useState(
-        localStorage.getItem(`${localStorage.getItem('provider') || 'openai'}_api_key`) || ''
-    );
+    const [apiKey, setApiKey] = useState('');
     const [humanMode, setHumanMode] = useState(false);
 
     const currentBranch = branches.find(b => b.id === currentBranchId) || branches[0];
@@ -41,7 +39,7 @@ function App() {
 
     useEffect(() => {
         storeProvider(provider);
-        setApiKey(localStorage.getItem(`${provider}_api_key`) || '');
+        setApiKey('');
     }, [provider]);
 
     useEffect(() => {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2,10 +2,10 @@ import axios from 'axios';
 
 let provider = localStorage.getItem('provider') || 'openai';
 const apiKeys = {
-    openai: localStorage.getItem('openai_api_key') || '',
-    anthropic: localStorage.getItem('anthropic_api_key') || '',
-    gemini: localStorage.getItem('gemini_api_key') || '',
-    llama: localStorage.getItem('llama_api_key') || '',
+    openai: '',
+    anthropic: '',
+    gemini: '',
+    llama: '',
 };
 
 export const setProvider = (p) => {
@@ -15,7 +15,6 @@ export const setProvider = (p) => {
 
 export const setApiKey = (key, p = provider) => {
     apiKeys[p] = key;
-    localStorage.setItem(`${p}_api_key`, key);
 };
 
 const callLLM = async (messages) => {


### PR DESCRIPTION
## Summary
- keep API keys only in memory
- update docs to match the new behavior

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6841289a577483329967dada54ccfbef