### PR TITLE
Fix duplicate exports in api service

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,3 @@
-export const setProvider = () => {};
-export const setApiKey = () => {};
 
 import axios from 'axios';
 


### PR DESCRIPTION
## Summary
- remove duplicate `setProvider` and `setApiKey` declarations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68412b32916c8332bf7e733d853a005d