### PR TITLE
Enable runtime provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ During early development you may not want to contact a real language model. The
   Gemini and local Llama.
 
 The chat interface defaults to a **Simulated** provider so you can test
-interactions without any API keys. When you're ready to connect to real LLMs
-switch the import in `App.js` to `llmApi.js` and choose one of the real
-providers from the dropdown.
+interactions without any API keys. Use the provider dropdown to select a real
+LLM when you're ready to connect. The app automatically routes requests to
+`llmApi.js` for the chosen provider.
 \nA small Node script `simulate.mjs` demonstrates this mock workflow on the command line. Run `node simulate.mjs` and enter a message to receive a fake response and listed characters.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,7 +4,7 @@ import {
     analyzeResponse,
     setApiKey as storeApiKey,
     setProvider as storeProvider,
-} from './services/api'; // swap to ./services/llmApi for real LLM calls
+} from './services';
 import { loadConversation, saveConversation, clearConversation } from './services/storage';
 import { generateId } from './utils/id';
 import './App.css';

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -1,0 +1,39 @@
+import * as simulated from './api';
+import * as llm from './llmApi';
+
+let provider = localStorage.getItem('provider') || 'simulated';
+
+simulated.setProvider(provider);
+llm.setProvider(provider);
+
+export const setProvider = (p) => {
+  provider = p;
+  simulated.setProvider(p);
+  llm.setProvider(p);
+};
+
+export const setApiKey = (key, p = provider) => {
+  simulated.setApiKey(key, p);
+  llm.setApiKey(key, p);
+};
+
+export const generateResponse = async (messages) => {
+  if (provider === 'simulated') {
+    return simulated.generateResponse(messages);
+  }
+  return llm.generateResponse(messages);
+};
+
+export const analyzeResponse = async (responseText, prevCharacters = []) => {
+  if (provider === 'simulated') {
+    return simulated.analyzeResponse(responseText, prevCharacters);
+  }
+  return llm.analyzeResponse(responseText, prevCharacters);
+};
+
+export default {
+  setProvider,
+  setApiKey,
+  generateResponse,
+  analyzeResponse,
+};


### PR DESCRIPTION
## Summary
- route API calls to llmApi when a real provider is selected
- update import in `App.js` to use the new service
- document provider dropdown behavior in README

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6841402706548332be9ab19633ebb976