### PR TITLE
Fix build error in services export

### DIFF
--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -31,9 +31,11 @@ export const analyzeResponse = async (responseText, prevCharacters = []) => {
   return llm.analyzeResponse(responseText, prevCharacters);
 };
 
-export default {
+const services = {
   setProvider,
   setApiKey,
   generateResponse,
   analyzeResponse,
 };
+
+export default services;


### PR DESCRIPTION
## Summary
- fix linter warning by giving default export a name

## Testing
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68414186efb48332ad9375ea2b854d0a